### PR TITLE
Add GetIasCamAsString Function and Associated Unit Tests

### DIFF
--- a/auth/token_test.go
+++ b/auth/token_test.go
@@ -5,6 +5,7 @@
 package auth
 
 import (
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 
@@ -13,6 +14,8 @@ import (
 )
 
 func TestToken_getClaimAsString(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name       string
 		claimValue interface{}
@@ -64,6 +67,8 @@ func TestToken_getClaimAsString(t *testing.T) {
 }
 
 func TestOIDCClaims_getClaimAsStringSlice(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name       string
 		claimValue interface{}
@@ -121,6 +126,8 @@ func TestOIDCClaims_getClaimAsStringSlice(t *testing.T) {
 }
 
 func TestOIDCClaims_getAllClaimsAsMap(t *testing.T) {
+	t.Parallel()
+
 	token, err := NewToken("eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3RLZXkiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOlsiY2xpZW50aWQiXSwiZW1haWwiOiJmb29AYmFyLm9yZyIsImV4cCI6MTYyMDA5MjI1MSwiZmFtaWx5X25hbWUiOiJCYXIiLCJnaXZlbl9uYW1lIjoiRm9vIiwiaWFzLWFkbWluIjoidHJ1ZSIsImlhdCI6MTYxOTc5MjI1MSwiaXNzIjoiaHR0cHM6Ly8xMjcuMC4wLjE6NTQ0ODIiLCJqdGkiOiI4NjI3NGE1Ny01N2FlLTQ5NDktOWRjOC03ODY0NjcyOWYzYmMiLCJuYmYiOjE2MTk3OTIyNTEsInVzZXJfdXVpZCI6IjIyMjIyMjIyLTMzMzMtNDQ0NC01NTU1LTY2NjY2NjY2NjY2NiIsInpvbmVfdXVpZCI6IjExMTExMTExLTIyMjItMzMzMy00NDQ0LTg4ODg4ODg4ODg4OCJ9.W-Owtad1oybqDI3tsJYGIIZPXBz2IdKOFoMCp07mv8kBNNVWNL0FbRIwilqU-cry_m-DA__5dKaVwaNW7q_6nCmIdvfmqdDJGCd6836AU4VC18uylSKMwVrm7o3TZsS04dDCjR5pnrSR2tzr-3VrMECRK7YSW4tuAaQC8XDWEnVIxz_l7eIB3v09SeRXi3iiqiYTUTyP3o5EU2Ae1tjYSfgLvOmkHTV406Rp5oaiZZV-jdMq7w-JaD-9JLon8O3XRdTApiYJ6yI9sXLcBrElHzy8M2HKm4FvOb66cJYT4GtB8Ntoq7XQKor0oW5dPPXuEBIl77Hz6PgNa7WYKkBi_w")
 	if err != nil {
 		t.Errorf("Error while preparing test: %v", err)
@@ -133,6 +140,8 @@ func TestOIDCClaims_getAllClaimsAsMap(t *testing.T) {
 }
 
 func TestOIDCClaims_getClaimAsMap(t *testing.T) {
+	t.Parallel()
+
 	token, err := NewToken("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbmYiOnsieDV0I1MyNTYiOiIwX3daeG5EUXd6dkxqLWh0NHNZbFQ3RzBIMURuT2ZPUC02MGFxeU1PVDI4IiwicHJvb2Z0b2tlbiI6InRydWUifX0.3Xi2fe-m-6lc1Ze9_AsnNpkYAG-LKFPHCld5EggQTW4")
 	require.NoError(t, err, "Error while preparing test: %v", err)
 
@@ -151,6 +160,8 @@ func TestOIDCClaims_getClaimAsMap(t *testing.T) {
 }
 
 func TestOIDCClaims_getSAPIssuer(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name          string
 		iss           string
@@ -192,6 +203,78 @@ func TestOIDCClaims_getSAPIssuer(t *testing.T) {
 			iasIssuerActual := token.Issuer()
 			if iasIssuerActual != tt.wantIss {
 				t.Errorf("Issuer() got = %v, want %v", iasIssuerActual, tt.wantIss)
+			}
+		})
+	}
+}
+
+func TestGetIasCamAsString(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		claims    map[string]interface{}
+		claimKey  string
+		want      []string
+		expectErr bool
+	}{
+		{
+			name: "Test single string claim",
+			claims: map[string]interface{}{
+				"claim1": "value1",
+			},
+			claimKey:  "claim1",
+			want:      []string{"value1"},
+			expectErr: false,
+		},
+		{
+			name: "Test array string claim",
+			claims: map[string]interface{}{
+				"claim2": []interface{}{"value2", "value3"},
+			},
+			claimKey:  "claim2",
+			want:      []string{"value2", "value3"},
+			expectErr: false,
+		},
+		{
+			name: "Test non-existing claim",
+			claims: map[string]interface{}{
+				"claim1": "value1",
+			},
+			claimKey:  "claim3",
+			expectErr: true,
+		},
+		{
+			name: "Test non-string claim",
+			claims: map[string]interface{}{
+				"claim3": 123,
+			},
+			claimKey:  "claim3",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			token := jwt.New()
+			for claim, value := range tc.claims {
+				err := token.Set(claim, value)
+				if err != nil {
+					return
+				}
+			}
+
+			testToken := Token{
+				jwtToken: token,
+			}
+
+			got, err := testToken.GetIasCamAsString(tc.claimKey)
+
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.want, got)
 			}
 		})
 	}


### PR DESCRIPTION
This PR introduces the `GetIasCamAsString` function in the `Token` struct which retrieves the value of a specified claim as a string or an array of strings. The key enhancement provided by this function is its ability to handle claim values that are either single strings or arrays of strings, returning all results as a slice of strings.

Changes include:
- Implementation of `GetIasCamAsString` function: The function accepts a JWT claim as input and returns its value as an array of strings. It handles claim values that are either strings or arrays of strings.
- Comprehensive unit tests for `GetIasCamAsString`: The tests cover various scenarios including single string claims, array of string claims, non-existing claims, and non-string claims.
- Refactoring of `CompanyGroups` function: Modified the function to leverage `GetIasCamAsString` function to handle claim values.


